### PR TITLE
WIP: specify stringsBundle in config (help wanted)

### DIFF
--- a/ios/Classes/TiFreshchatModule.swift
+++ b/ios/Classes/TiFreshchatModule.swift
@@ -40,7 +40,8 @@ class TiFreshchatModule: TiModule {
     let appId = params["appId"]
     let appKey = params["appKey"]
     let domain = params["domain"]
-    
+    let stringsBundle = params["stringsBundle"]
+
     guard let appId, let appKey else {
       fatalError("appId or appKey is not set")
     }
@@ -48,6 +49,10 @@ class TiFreshchatModule: TiModule {
     let config = FreshchatConfig.init(appID: appId, andAppKey: appKey)
     if let domain {
       config.domain = domain
+    }
+
+    if let stringsBundle {
+      config.stringsBundle = stringsBundle
     }
     
     Freshchat.sharedInstance().initWith(config)


### PR DESCRIPTION
added stringsBundle key to specify localization bundle.

Missing adding the localization bundle as described in 
https://support.freshchat.com/en/support/solutions/articles/50000000048-freshchat-ios-sdk-integration-steps 

section 7.3
